### PR TITLE
Replace example window with dedicated example editor in the `usd_qtpy` lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Unlike [Luma Pictures's  `usd-qt`](https://github.com/LumaPictures/usd-qt) this 
 redistributable by avoiding the need for extra C++ dependencies and solely
 use the USD Python API. This will keep the build matrix simpler but does mean
 the repository is not - by design - built for highly optimized large scale 
-applications. Nonetheless the intent is still to be able to carry average VFX 
+applications. Nonetheless, the intent is still to be able to carry average VFX 
 scenes for debugging.
 
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,50 @@
 Python Qt components for building custom USD tools.
 
 
+#### How to use?
+
+The Qt components can be embedded in your own Qt interfaces and usually have
+a `stage` entrypoint that you should pass a `pxr.Usd.Stage` instance.
+
+However, a simple example Editor UI is also available to run standalone.
+If you have the `usd_qtpy` package you can for example run it like:
+
+```
+python -m usd_qtpy "/path/to/file.usd"
+```
+
+Want to try it within your running Python session it should be as trivial to
+do: 
+
+```python
+from pxr import Usd
+from qtpy import QtWidgets
+from usd_qtpy.editor import EditorWindow
+
+filepath = "/path/to/file.usd"
+stage = Usd.Stage.Open(filepath)
+
+app = QtWidgets.QApplication()
+dialog = EditorWindow(stage=stage)
+dialog.resize(600, 600)
+dialog.show()
+app.exec_()
+```
+
+Or if you have a running `QApplication` instance (e.g. when inside Maya):
+
+```python
+from pxr import Usd
+from usd_qtpy.editor import EditorWindow
+
+filepath = "/path/to/file.usd"
+stage = Usd.Stage.Open(filepath)
+
+dialog = EditorWindow(stage=stage)
+dialog.resize(600, 600)
+dialog.show()
+```
+
 #### Why not Luma Picture's `usd-qt`?
 
 Unlike [Luma Pictures's  `usd-qt`](https://github.com/LumaPictures/usd-qt) this repository tries to be easily 

--- a/usd_qtpy/__main__.py
+++ b/usd_qtpy/__main__.py
@@ -1,0 +1,36 @@
+import os
+import argparse
+
+
+parser = argparse.ArgumentParser(
+    prog='usd_qtpy',
+    description='USD Editor built in Python using Qt',
+)
+parser.add_argument(
+    'filepath',
+    help="USD filepath open in the example editor")
+
+
+def main():
+    args = parser.parse_args()
+    filepath = args.filepath
+
+    if not os.path.exists(filepath):
+        raise RuntimeError(f"USD file does not exist: {filepath}")
+
+    # Import here so that one get the argparse help even if relevant libraries
+    # are not installed
+    from pxr import Usd  # noqa
+    from qtpy import QtWidgets  # noqa
+    from usd_qtpy.editor import EditorWindow  # noqa
+
+    stage = Usd.Stage.Open(filepath)
+    app = QtWidgets.QApplication()
+    dialog = EditorWindow(stage=stage)
+    dialog.show()
+    dialog.resize(600, 600)
+    app.exec_()
+
+
+if __name__ == "__main__":
+    main()

--- a/usd_qtpy/__main__.py
+++ b/usd_qtpy/__main__.py
@@ -27,8 +27,8 @@ def main():
     stage = Usd.Stage.Open(filepath)
     app = QtWidgets.QApplication()
     dialog = EditorWindow(stage=stage)
-    dialog.show()
     dialog.resize(600, 600)
+    dialog.show()
     app.exec_()
 
 

--- a/usd_qtpy/editor.py
+++ b/usd_qtpy/editor.py
@@ -1,19 +1,26 @@
-from qtpy import QtWidgets
-from pxr import Usd
+import logging
 
-from usd_qtpy import prim_hierarchy, layer_editor, prim_spec_editor
+from qtpy import QtWidgets
+
+from . import (
+    prim_hierarchy,
+    layer_editor,
+    prim_spec_editor
+)
+
 
 try:
     from usd_qtpy import viewer
     HAS_VIEWER = True
 except ImportError:
-    print("Unable to import usdview dependencies, skipping view..")
+    logging.warning("Unable to import usdview dependencies, skipping view..")
     HAS_VIEWER = False
 
 
-class Window(QtWidgets.QDialog):
+class EditorWindow(QtWidgets.QDialog):
+    """Example editor window containing the available components."""
     def __init__(self, stage, parent=None):
-        super(Window, self).__init__(parent=parent)
+        super(EditorWindow, self).__init__(parent=parent)
 
         self.setWindowTitle("USD Editor")
 
@@ -21,15 +28,15 @@ class Window(QtWidgets.QDialog):
         splitter = QtWidgets.QSplitter(self)
         layout.addWidget(splitter)
 
-        layers = layer_editor.LayerTreeWidget(
+        layer_tree_widget = layer_editor.LayerTreeWidget(
             stage=stage,
             include_session_layer=False,
             parent=self
         )
-        splitter.addWidget(layers)
+        splitter.addWidget(layer_tree_widget)
 
-        hierarchy = prim_hierarchy.HierarchyWidget(stage=stage)
-        splitter.addWidget(hierarchy)
+        hierarchy_widget = prim_hierarchy.HierarchyWidget(stage=stage)
+        splitter.addWidget(hierarchy_widget)
 
         if HAS_VIEWER:
             viewer_widget = viewer.Widget(stage=stage)
@@ -37,13 +44,3 @@ class Window(QtWidgets.QDialog):
 
         prim_spec_editor_widget = prim_spec_editor.SpecEditorWindow(stage=stage)
         splitter.addWidget(prim_spec_editor_widget)
-
-
-if __name__ == "__main__":
-    path = "/path/to/usd/file.usda"
-    stage = Usd.Stage.Open(path)
-    app = QtWidgets.QApplication()
-    dialog = Window(stage=stage)
-    dialog.show()
-    dialog.resize(600, 600)
-    app.exec_()

--- a/usd_qtpy/prim_spec_editor.py
+++ b/usd_qtpy/prim_spec_editor.py
@@ -5,12 +5,12 @@ from PySide2 import QtCore, QtWidgets, QtGui
 
 from .lib.qt import schedule
 from .lib.usd import remove_spec, LIST_ATTRS
+from .tree.simpletree import TreeModel, Item
 
 
 log = logging.getLogger(__name__)
 
-
-# See: https://github.com/PixarAnimationStudios/OpenUSD/blob/release/pxr/usd/sdf/fileIO_Common.cpp#L879-L892
+# See: https://github.com/PixarAnimationStudios/OpenUSD/blob/release/pxr/usd/sdf/fileIO_Common.cpp#L879-L892  # noqa
 SPECIFIER_LABEL = {
     Sdf.SpecifierDef: "def",
     Sdf.SpecifierOver: "over",
@@ -25,157 +25,8 @@ def shorten(s, width, placeholder="..."):
     return "{}{}".format(s[:width], placeholder)
 
 
-class TreeModel(QtCore.QAbstractItemModel):
-    Columns = list()
-    ItemRole = QtCore.Qt.UserRole + 1
-
-    def __init__(self, parent=None):
-        super(TreeModel, self).__init__(parent)
-        self._root_item = Item()
-
-    def rowCount(self, parent=None):
-        if parent is None or not parent.isValid():
-            parent_item = self._root_item
-        else:
-            parent_item = parent.internalPointer()
-        return parent_item.childCount()
-
-    def columnCount(self, parent):
-        return len(self.Columns)
-
-    def data(self, index, role):
-        if not index.isValid():
-            return None
-
-        if role == QtCore.Qt.DisplayRole:
-            item = index.internalPointer()
-            column = index.column()
-
-            key = self.Columns[column]
-            return item.get(key, None)
-
-        if role == self.ItemRole:
-            return index.internalPointer()
-
-    def setColumns(self, keys):
-        assert isinstance(keys, (list, tuple))
-        self.Columns = keys
-
-    def headerData(self, section, orientation, role):
-
-        if role == QtCore.Qt.DisplayRole:
-            if section < len(self.Columns):
-                return self.Columns[section]
-        return
-
-        return super(TreeModel, self).headerData(section, orientation, role)
-
-    def flags(self, index):
-        flags = QtCore.Qt.ItemIsEnabled
-
-        item = index.internalPointer()
-        if item.get("enabled", True):
-            flags |= QtCore.Qt.ItemIsSelectable
-
-        return flags
-
-    def parent(self, index):
-
-        item = index.internalPointer()
-        parent_item = item.parent()
-
-        # If it has no parents we return invalid
-        if parent_item == self._root_item or not parent_item:
-            return QtCore.QModelIndex()
-
-        return self.createIndex(parent_item.row(), 0, parent_item)
-
-    def index(self, row, column, parent=None):
-        """Return index for row/column under parent"""
-
-        if parent is None or not parent.isValid():
-            parent_item = self._root_item
-        else:
-            parent_item = parent.internalPointer()
-
-        child_item = parent_item.child(row)
-        if child_item:
-            return self.createIndex(row, column, child_item)
-        else:
-            return QtCore.QModelIndex()
-
-    def add_child(self, item, parent=None):
-        if parent is None:
-            parent = self._root_item
-
-        parent.add_child(item)
-
-    def column_name(self, column):
-        """Return column key by index"""
-
-        if column < len(self.Columns):
-            return self.Columns[column]
-
-    def clear(self):
-        self.beginResetModel()
-        self._root_item = Item()
-        self.endResetModel()
-
-
-class Item(dict):
-    """An item that can be represented in a tree view using `TreeModel`.
-
-    The item can store data just like a regular dictionary.
-
-    >>> data = {"name": "John", "score": 10}
-    >>> item = Item(data)
-    >>> assert item["name"] == "John"
-
-    """
-
-    def __init__(self, data=None):
-        super(Item, self).__init__()
-
-        self._children = list()
-        self._parent = None
-
-        if data is not None:
-            assert isinstance(data, dict)
-            self.update(data)
-
-    def childCount(self):
-        return len(self._children)
-
-    def child(self, row):
-
-        if row >= len(self._children):
-            log.warning("Invalid row as child: %s", row)
-            return
-
-        return self._children[row]
-
-    def children(self):
-        return self._children
-
-    def parent(self):
-        return self._parent
-
-    def row(self):
-        """
-        Returns:
-             int: Index of this item under parent"""
-        if self._parent is not None:
-            siblings = self.parent().children()
-            return siblings.index(self)
-        return -1
-
-    def add_child(self, child):
-        """Add a child to this item"""
-        child._parent = self
-        self._children.append(child)
-
-
 class StageSdfModel(TreeModel):
+    """Model listing a Stage's Layers and PrimSpecs"""
     Columns = [
         "name", "specifier", "typeName", "default", "type",
         # "variantSelections", "variantSetNameList", "variantSets",
@@ -321,11 +172,11 @@ class StageSdfModel(TreeModel):
         return super(StageSdfModel, self).data(index, role)
 
 
-class Proxy(QtCore.QSortFilterProxyModel):
+class PrimSpectTypeFilterProxy(QtCore.QSortFilterProxyModel):
 
     def __init__(self, *args, **kwargs):
-        super(Proxy, self).__init__(*args, **kwargs)
-        self._filter_types = {"RelationshipSpec"}
+        super(PrimSpectTypeFilterProxy, self).__init__(*args, **kwargs)
+        self._filter_types = set()
 
     def set_types_filter(self, types):
         self._filter_types = set(types)
@@ -346,7 +197,8 @@ class Proxy(QtCore.QSortFilterProxyModel):
         ):
             return False
 
-        return super(Proxy, self).filterAcceptsRow(source_row, source_parent)
+        return super(PrimSpectTypeFilterProxy,
+                     self).filterAcceptsRow(source_row, source_parent)
 
 
 class FilterListWidget(QtWidgets.QListWidget):
@@ -414,7 +266,7 @@ class SpecEditsWidget(QtWidgets.QWidget):
         filter_edit.setPlaceholderText("Filter")
 
         model = StageSdfModel(stage)
-        proxy = Proxy()
+        proxy = PrimSpectTypeFilterProxy()
         proxy.setRecursiveFilteringEnabled(True)
         proxy.setSourceModel(model)
         view = QtWidgets.QTreeView()

--- a/usd_qtpy/tree/simpletree.py
+++ b/usd_qtpy/tree/simpletree.py
@@ -1,4 +1,8 @@
+import logging
+
 from PySide2 import QtCore
+
+log = logging.getLogger(__name__)
 
 
 class TreeModel(QtCore.QAbstractItemModel):

--- a/usd_qtpy/tree/simpletree.py
+++ b/usd_qtpy/tree/simpletree.py
@@ -1,0 +1,151 @@
+from PySide2 import QtCore
+
+
+class TreeModel(QtCore.QAbstractItemModel):
+    Columns = list()
+    ItemRole = QtCore.Qt.UserRole + 1
+
+    def __init__(self, parent=None):
+        super(TreeModel, self).__init__(parent)
+        self._root_item = Item()
+
+    def rowCount(self, parent=None):
+        if parent is None or not parent.isValid():
+            parent_item = self._root_item
+        else:
+            parent_item = parent.internalPointer()
+        return parent_item.childCount()
+
+    def columnCount(self, parent):
+        return len(self.Columns)
+
+    def data(self, index, role):
+        if not index.isValid():
+            return None
+
+        if role == QtCore.Qt.DisplayRole:
+            item = index.internalPointer()
+            column = index.column()
+
+            key = self.Columns[column]
+            return item.get(key, None)
+
+        if role == self.ItemRole:
+            return index.internalPointer()
+
+    def setColumns(self, keys):
+        assert isinstance(keys, (list, tuple))
+        self.Columns = keys
+
+    def headerData(self, section, orientation, role):
+
+        if role == QtCore.Qt.DisplayRole:
+            if section < len(self.Columns):
+                return self.Columns[section]
+        return
+
+        return super(TreeModel, self).headerData(section, orientation, role)
+
+    def flags(self, index):
+        flags = QtCore.Qt.ItemIsEnabled
+
+        item = index.internalPointer()
+        if item.get("enabled", True):
+            flags |= QtCore.Qt.ItemIsSelectable
+
+        return flags
+
+    def parent(self, index):
+
+        item = index.internalPointer()
+        parent_item = item.parent()
+
+        # If it has no parents we return invalid
+        if parent_item == self._root_item or not parent_item:
+            return QtCore.QModelIndex()
+
+        return self.createIndex(parent_item.row(), 0, parent_item)
+
+    def index(self, row, column, parent=None):
+        """Return index for row/column under parent"""
+
+        if parent is None or not parent.isValid():
+            parent_item = self._root_item
+        else:
+            parent_item = parent.internalPointer()
+
+        child_item = parent_item.child(row)
+        if child_item:
+            return self.createIndex(row, column, child_item)
+        else:
+            return QtCore.QModelIndex()
+
+    def add_child(self, item, parent=None):
+        if parent is None:
+            parent = self._root_item
+
+        parent.add_child(item)
+
+    def column_name(self, column):
+        """Return column key by index"""
+
+        if column < len(self.Columns):
+            return self.Columns[column]
+
+    def clear(self):
+        self.beginResetModel()
+        self._root_item = Item()
+        self.endResetModel()
+
+
+class Item(dict):
+    """An item that can be represented in a tree view using `TreeModel`.
+
+    The item can store data just like a regular dictionary.
+
+    >>> data = {"name": "John", "score": 10}
+    >>> item = Item(data)
+    >>> assert item["name"] == "John"
+
+    """
+
+    def __init__(self, data=None):
+        super(Item, self).__init__()
+
+        self._children = list()
+        self._parent = None
+
+        if data is not None:
+            assert isinstance(data, dict)
+            self.update(data)
+
+    def childCount(self):
+        return len(self._children)
+
+    def child(self, row):
+
+        if row >= len(self._children):
+            log.warning("Invalid row as child: %s", row)
+            return
+
+        return self._children[row]
+
+    def children(self):
+        return self._children
+
+    def parent(self):
+        return self._parent
+
+    def row(self):
+        """
+        Returns:
+             int: Index of this item under parent"""
+        if self._parent is not None:
+            siblings = self.parent().children()
+            return siblings.index(self)
+        return -1
+
+    def add_child(self, child):
+        """Add a child to this item"""
+        child._parent = self
+        self._children.append(child)


### PR DESCRIPTION
As a replacement to #8 this exposes the example editor to command-line to open with a USD file.

In the form of:
```python
python -m usd_qtpy "/path/to/file.usd"
```

There's also some minor restructuring of a base class which isn't necessarily crucial to the change but had to be done either way, so I included it here.

---

@Sasbom would this work for you?

@MustafaJafar would you say this is an improvement on making it easier to get started? or harder? Since you ran the earlier example window before I wonder if that was easier. Note how [the updated readme](https://github.com/BigRoy/usd-qtpy/blob/fbb1c1a76a08dddde7e8b71eb62b0a73823bfecf/README.md) still provides examples to run directly from e.g. Python code as well. Does that suffice?