### PR TITLE
Enhancement: Implement Layer Editor add remove layers

### DIFF
--- a/usd_qtpy/layer_editor.py
+++ b/usd_qtpy/layer_editor.py
@@ -56,7 +56,7 @@ class LayerItem(TreeItem):
 
     def __init__(self, layer: Sdf.Layer, parent_layer: Sdf.Layer = None):
         if parent_layer:
-            separator = "<--sublayer-->"  #
+            separator = "<--sublayer-->"
             key = separator.join([parent_layer.identifier, layer.identifier])
         else:
             key = layer.identifier

--- a/usd_qtpy/layer_editor.py
+++ b/usd_qtpy/layer_editor.py
@@ -197,7 +197,7 @@ class LayerStackModel(AbstractTreeModelMixin, QtCore.QAbstractItemModel):
                                                             column,
                                                             parent)
 
-        # endregion
+    # endregion
 
     # region Custom methods
     def layer_count(self):

--- a/usd_qtpy/layer_editor.py
+++ b/usd_qtpy/layer_editor.py
@@ -311,6 +311,7 @@ class LayerStackModel(AbstractTreeModelMixin, QtCore.QAbstractItemModel):
         # rebuilding the layer list then at all actually. But we need the
         # signal otherwise we can't detect layers added/removed to begin with.
         schedule(self.refresh, 50, channel="layerschanged")
+    # endregion
 
 
 class LayerWidget(QtWidgets.QWidget):

--- a/usd_qtpy/layer_editor.py
+++ b/usd_qtpy/layer_editor.py
@@ -467,8 +467,8 @@ class LayerWidget(QtWidgets.QWidget):
         # TODO: Perform an actual save
         # TODO: Prompt for filepath if layer is anonymous?
         # TODO: Allow making filepath relative to parent layer?
-        print(f"Saving: {layer}")
-        print(layer.ExportToString())
+        log.debug(f"Saving: {layer}")
+        log.debug(layer.ExportToString())
         layer.Save()
         # TODO: Do not update using this but base it off of signals from
         #  Sdf.Notice.LayerDidSaveLayerToFile
@@ -550,7 +550,7 @@ class LayerTreeWidget(QtWidgets.QWidget):
                 "Shows the layer as USD ASCII"
             )
 
-            def show_layer():
+            def show_layer_as_text():
                 text_edit = QtWidgets.QTextEdit(parent=self)
                 text_edit.setPlainText(layer.ExportToString())
                 text_edit.setWindowTitle(layer.identifier)
@@ -558,7 +558,7 @@ class LayerTreeWidget(QtWidgets.QWidget):
                 text_edit.resize(700, 500)
                 text_edit.show()
 
-            action.triggered.connect(show_layer)
+            action.triggered.connect(show_layer_as_text)
 
         menu.exec_(self.view.mapToGlobal(point))
 
@@ -571,7 +571,7 @@ class LayerTreeWidget(QtWidgets.QWidget):
         for row in iter_model_rows(self.model, column=0):
             layer = row.data(self.model.LayerRole)
             if layer is None:
-                print(f"Layer is None for {row}")
+                log.warning(f"Layer is None for %s", row)
                 continue
             widget = LayerWidget(layer=layer,
                                  stage=self.model._stage,

--- a/usd_qtpy/prim_spec_editor.py
+++ b/usd_qtpy/prim_spec_editor.py
@@ -368,7 +368,7 @@ class SpecEditsWidget(QtWidgets.QWidget):
 
         with Sdf.ChangeBlock():
             for spec in specs:
-                print(f"Removing spec: {spec.path}")
+                log.debug(f"Removing spec: %s", spec.path)
                 remove_spec(spec)
 
         if not self._listeners:

--- a/usd_qtpy/viewer.py
+++ b/usd_qtpy/viewer.py
@@ -472,8 +472,6 @@ class Widget(QtWidgets.QWidget):
         # Implement some shortcuts for the widget
         # todo: move this code
 
-        print(event)
-
         key = event.key()
         # TODO: Add CTRL + R for "quick render or playblast"
         if key == QtCore.Qt.Key_Space:


### PR DESCRIPTION
Implements:

- You can now right click a sublayer to remove it from the layer stack - fix #2 
- You can now right click "add layer" to pick files from disk to add as sublayers - fix #2 
- You can now drag an drop usd files from your OS file explorer (e.g. Windows Explorer) onto the layer list

Fixes:

- This also fixes an issue where the same layer identifier across the layer stack (e.g. present in different sublayers) would error in the model on the uniqueness of the key - those are now made unique by using the key `{parent.identifier}-sublayer->{layer.identifier}`
- Some minor cosmetics - some print statements are now log messages.