### PR TITLE
Enhancement: Add a simple Show Layer Diff widget

### DIFF
--- a/usd_qtpy/layer_diff.py
+++ b/usd_qtpy/layer_diff.py
@@ -1,0 +1,115 @@
+import difflib
+
+from qtpy import QtWidgets, QtCore
+from pxr import Sdf, Tf
+
+from .lib.qt import DifflibSyntaxHighlighter
+
+
+class LayerDiffWidget(QtWidgets.QDialog):
+    """Simple layer ASCII diff text view"""
+    # TODO: Add a dedicated 'toggle listen' and 'refresh' button to the widget
+    #   so a user can only refresh e.g. when manually requested - especially
+    #   since listing diffs can be slow (especially on large files)
+    def __init__(self,
+                 layer_a: Sdf.Layer,
+                 layer_b: Sdf.Layer = None,
+                 layer_a_label: str = None,
+                 layer_b_label: str = None,
+                 listen: bool = True,
+                 parent: QtCore.QObject = None):
+        super(LayerDiffWidget, self).__init__(parent=parent)
+
+        self.setWindowTitle("USD Layer Diff")
+
+        layout = QtWidgets.QVBoxLayout(self)
+        text_edit = QtWidgets.QTextEdit()
+
+        # Force monospace font for readability
+        text_edit.setStyleSheet('* { font-family: "Courier"; }')
+        highlighter = DifflibSyntaxHighlighter(text_edit)
+        text_edit.setPlaceholderText("Layers match - no difference detected.")
+
+        layout.addWidget(text_edit)
+
+        if layer_b is None:
+            # Load a clean copy (without unsaved changes) to compare with
+            # its non-dirty state easily.
+            layer_b = Sdf.Layer.OpenAsAnonymous(layer_a.identifier)
+            # We will swap A/B around so that the layer from disk is the
+            # "old" state in A
+            layer_a, layer_b = layer_b, layer_a
+
+        self._listen = listen
+        self._text_edit = text_edit
+        self._highlighter = highlighter
+        self._layer_a = layer_a
+        self._layer_b = layer_b
+        self._layer_a_label = layer_a_label
+        self._layer_b_label = layer_b_label
+        self._listeners = []
+
+        if not listen:
+            self.refresh()
+
+    def refresh(self):
+
+        layer_a = self._layer_a
+        layer_b = self._layer_b
+        a_ascii = layer_a.ExportToString()
+        b_ascii = layer_b.ExportToString()
+
+        # Print diff
+        self._text_edit.clear()
+        for line in difflib.unified_diff(
+            a_ascii.splitlines(),
+            b_ascii.splitlines(),
+            fromfile=self._layer_a_label or f"{layer_a.identifier} (A)",
+            tofile=self._layer_b_label or f"{layer_b.identifier} (B)",
+            lineterm=""
+        ):
+            self._text_edit.insertPlainText(f"{line}\n")
+
+    def on_layers_changed(self, notice, sender):
+        # TODO: We could also cache the ASCII of the USD files so that on
+        #  layer change we only perform the `layer.ExportToString` on only the
+        #  changed layer - optimizing this logic further.
+        # TODO: Add a `schedule` call so that we delay the refresh ever so
+        #  so slightly to avoid continuous refreshing when e.g. moving prims
+        #  interactively in the viewport in Maya - we might want to put that
+        #  behind a flag to toggle on/off to still allow interactive updates
+        #  too
+        self.refresh()
+
+    def _register_listeners(self):
+
+        self._listeners.append(Tf.Notice.Register(
+            Sdf.Notice.LayersDidChangeSentPerLayer,
+            self.on_layers_changed,
+            self._layer_a
+        ))
+
+        self._listeners.append(Tf.Notice.Register(
+            Sdf.Notice.LayersDidChangeSentPerLayer,
+            self.on_layers_changed,
+            self._layer_b
+        ))
+
+    def _revoke_listeners(self):
+        for listener in self._listeners:
+            listener.Revoke()
+        self._listeners.clear()
+
+    def showEvent(self, event):
+
+        if self._listen:
+            # Update whatever we missed while we were hidden
+            # and re-attach any listeners
+            self.refresh()
+            self._register_listeners()
+
+    def hideEvent(self, event):
+
+        if self._listen:
+            # Don't list while hidden
+            self._revoke_listeners()

--- a/usd_qtpy/layer_editor.py
+++ b/usd_qtpy/layer_editor.py
@@ -10,6 +10,7 @@ from pxr import Sdf, Usd, Tf
 from .tree.itemtree import ItemTree, TreeItem
 from .tree.base import AbstractTreeModelMixin
 from .lib.qt import schedule, iter_model_rows
+from .layer_diff import LayerDiffWidget
 
 log = logging.getLogger(__name__)
 
@@ -605,6 +606,23 @@ class LayerTreeWidget(QtWidgets.QWidget):
                 text_edit.show()
 
             action.triggered.connect(show_layer_as_text)
+
+            action = menu.addAction("Show diff")
+            action.setToolTip(
+                "Show a USD ASCII diff for the unsaved changes comparing "
+                "to the layer on disk"
+            )
+            action.setEnabled(not layer.anonymous)
+
+            def show_layer_diff():
+                widget = LayerDiffWidget(
+                    layer,
+                    layer_a_label=f"{layer.identifier} (on disk)",
+                    layer_b_label=f"{layer.identifier} (active)",
+                    parent=self)
+                widget.show()
+
+            action.triggered.connect(show_layer_diff)
 
         menu.exec_(self.view.mapToGlobal(point))
 


### PR DESCRIPTION
This PR adds a very minimal "Layer Diff" widget that shows the ASCII diff between two layers.

As an example this now also adds it to the context menu for the Layer Tree Widget so that a user can right click a (saved; non-anonymous) layer and click "Show diff".

Here's a demo live in Maya on how that would work:

https://github.com/BigRoy/usd-qtpy/assets/2439881/15606ade-bfcd-42b3-89c2-97a7061f280a

_Note: This again I'm currently demoing with the [stylesheet from OpenPype](https://github.com/ynput/OpenPype) which is not in this repository_
