### PR TITLE
Enhancement: Add Variant Set management

### DIFF
--- a/usd_qtpy/lib/usd.py
+++ b/usd_qtpy/lib/usd.py
@@ -192,7 +192,25 @@ def rename_prim(prim: Usd.Prim, new_name: str) -> bool:
         return True
 
     prim_path = prim.GetPath()
-    new_prim_path = prim_path.GetParentPath().AppendChild(new_name)
+    new_prim_path = prim_path.ReplaceName(new_name)
+
+    # We want to map the path to the current edit target of its stage so that
+    # if the user is renaming a prim in an edit target currently editing
+    # within a variant set, that we rename that particular opinion. However,
+    # we only do that if the source prim path existed in the edit target
+    # otherwise we will edit it on the layer regularly
+    # WARNING This will crash on calls to `prim.GetPrimStack()` afterwards
+    #   See: https://forum.aousd.org/t/perform-namespace-edit-inside-a-variant-set-edit-target/1006
+    # stage = prim.GetStage()
+    # edit_target = stage.GetEditTarget()
+    # remapped_prim_path = edit_target.MapToSpecPath(prim_path)
+    # if (
+    #         prim_path != remapped_prim_path
+    # ):
+    #     logging.debug("Remapping prim path to within edit target: %s",
+    #                   remapped_prim_path)
+    #     prim_path = remapped_prim_path
+    #     new_prim_path = edit_target.MapToSpecPath(new_prim_path)
 
     stage = prim.GetStage()
     with Sdf.ChangeBlock():

--- a/usd_qtpy/lib/usd.py
+++ b/usd_qtpy/lib/usd.py
@@ -225,7 +225,12 @@ def remove_spec(spec):
         del spec.owner.properties[spec.name]
 
     elif isinstance(spec, Sdf.VariantSetSpec):
+        # Owner is Sdf.PrimSpec (or can also be Sdf.VariantSpec)
         del spec.owner.variantSets[spec.name]
+
+    elif isinstance(spec, Sdf.VariantSpec):
+        # Owner is Sdf.VariantSetSpec
+        spec.owner.RemoveVariant(spec)
 
     else:
         raise TypeError(f"Unsupported spec type: {spec}")

--- a/usd_qtpy/prim_hierarchy.py
+++ b/usd_qtpy/prim_hierarchy.py
@@ -7,7 +7,7 @@ from .lib.usd import get_prim_types_by_group
 from .prim_delegate import DrawRectsDelegate
 from .prim_hierarchy_model import HierarchyModel
 from .references import ReferenceListWidget
-from .variants import CreateVariantSetDialog
+from .variants import CreateVariantSetDialog, VariantSetsWidget
 
 
 class View(QtWidgets.QTreeView):
@@ -162,7 +162,10 @@ class View(QtWidgets.QTreeView):
             self.on_manage_prim_reference_payload(prim)
 
         elif text == "VAR":
-            raise NotImplementedError("To be implemented")
+            prim = index.data(HierarchyModel.PrimRole)
+            widget = VariantSetsWidget(prim=prim, parent=self)
+            widget.resize(250, 100)
+            widget.show()
 
 
 class HierarchyWidget(QtWidgets.QDialog):

--- a/usd_qtpy/prim_spec_editor.py
+++ b/usd_qtpy/prim_spec_editor.py
@@ -291,6 +291,10 @@ class StageSdfModel(TreeModel):
             item = index.data(TreeModel.ItemRole)
             return item.get("icon")
 
+        if role == QtCore.Qt.ToolTipRole:
+            item = index.data(TreeModel.ItemRole)
+            return item.get("path")
+
         return super(StageSdfModel, self).data(index, role)
 
 

--- a/usd_qtpy/prim_spec_editor.py
+++ b/usd_qtpy/prim_spec_editor.py
@@ -366,13 +366,14 @@ class FilterListWidget(QtWidgets.QListWidget):
         tooltips = {
             "Layer": "A single <b>Layer</b> in the stage.",
             "PrimSpec": "A <b>Prim</b> description",
-            "AttributeSpec": "A property that holds typed data.",
             "reference": "Represents a reference.",
             "payload": (
                 "Represents a payload.<br>"
                 "Payloads are similar to prim references with the major "
                 "difference that payloads are explicitly loaded by the user."
             ),
+            "relocates": "Namespace relocations specified on a prim",
+            "AttributeSpec": "A property that holds typed data.",
             "RelationshipSpec": (
                 "A property that contains a reference to "
                 "one or more prim specs."

--- a/usd_qtpy/prim_spec_editor.py
+++ b/usd_qtpy/prim_spec_editor.py
@@ -89,12 +89,14 @@ class StageSdfModel(TreeModel):
         "Layer": QtGui.QColor("#008EC5"),
         "PseudoRootSpec": QtGui.QColor("#A2D2EF"),
         "PrimSpec": QtGui.QColor("#A2D2EF"),
-        "VariantSetSpec": QtGui.QColor("#A2D2EF"),
         "RelationshipSpec": QtGui.QColor("#FCD057"),
         "AttributeSpec": QtGui.QColor("#FFC8DD"),
         "reference": QtGui.QColor("#C8DDDD"),
         "payload": QtGui.QColor("#DDC8DD"),
-        "variantSetName":  QtGui.QColor("#DDDDC8"),
+        "VariantSetSpec": QtGui.QColor("#AAE48B"),
+        "VariantSpec":  QtGui.QColor("#D6E8CC"),
+        "variantSetName":  QtGui.QColor("#D6E8CC"),
+        "variantSelections":  QtGui.QColor("#D6E8CC"),
     }
 
     def __init__(self, stage=None, parent=None):
@@ -145,6 +147,10 @@ class StageSdfModel(TreeModel):
                     "type": spec.__class__.__name__
                 })
 
+                element_string = spec.path.elementString
+                if element_string and spec.name != element_string:
+                    spec_item["name"] = element_string
+
                 if hasattr(spec, "GetTypeName"):
                     spec_type_name = spec.GetTypeName()
                     icon = self._icon_provider.get_icon_from_type_name(
@@ -169,15 +175,8 @@ class StageSdfModel(TreeModel):
                     type_name = spec.typeName
                     spec_item["typeName"] = type_name
 
-                    for attr in [
-                        "variantSelections",
-                        "relocates",
-                        # Variant sets is redundant because these basically
-                        # refer to VariantSetSpecs which will actually be
-                        # traversed path in the layer anyway
-                        # TODO: Remove this commented key?
-                        # "variantSets"
-                    ]:
+                    def _add_map_item(attr):
+                        """Add MapProxyItem for list attribute on Spec"""
                         proxy = getattr(spec, attr)
 
                         # `prim_spec.variantSelections.keys()` can fail
@@ -185,7 +184,7 @@ class StageSdfModel(TreeModel):
                         try:
                             keys = list(proxy.keys())
                         except RuntimeError:
-                            continue
+                            return
 
                         for key in keys:
                             proxy_item = MapProxyItem(
@@ -194,17 +193,15 @@ class StageSdfModel(TreeModel):
                                 data={
                                     "name": key,
                                     "default": proxy.get(key),  # value
-                                    "type": attr
+                                    "type": attr,
+                                    "typeName": attr,
                                 }
                             )
                             spec_item.add_child(proxy_item)
 
-                    for key in [
-                        "variantSetName",
-                        "reference",
-                        "payload"
-                    ]:
-                        list_changes = getattr(spec, key + "List")
+                    def _add_list_item(attr):
+                        """Add ListProxyItem for list attribute on Spec"""
+                        list_changes = getattr(spec, attr + "List")
                         for change_type in LIST_ATTRS:
                             changes_for_type = getattr(list_changes,
                                                        change_type)
@@ -224,14 +221,26 @@ class StageSdfModel(TreeModel):
                                         "name": name,
                                         # Strip off "Items"
                                         "default": change_type[:-5],
-                                        "type": key,
-                                        "typeName": key,
+                                        "type": attr,
+                                        "typeName": attr,
                                         "parent": changes_for_type
                                     }
                                 )
                                 spec_item.add_child(list_change_item)
                         if list_changes:
-                            spec_item[key] = str(list_changes)
+                            spec_item[attr] = str(list_changes)
+
+                    # Add these types intermixed just so we order attributes
+                    # together nicely that are somewhat related, e.g. variant
+                    # information together
+                    for attr, add_fn in [
+                        ("reference", _add_list_item),
+                        ("payload", _add_list_item),
+                        ("relocates", _add_map_item),
+                        ("variantSelections", _add_map_item),
+                        ("variantSetName", _add_list_item),
+                    ]:
+                        add_fn(attr)
 
                 elif isinstance(spec, Sdf.AttributeSpec):
                     value = spec.default
@@ -330,23 +339,58 @@ class PrimSpectTypeFilterProxy(QtCore.QSortFilterProxyModel):
 class FilterListWidget(QtWidgets.QListWidget):
     def __init__(self):
         super(FilterListWidget, self).__init__()
-        self.addItems([
+
+        # Some labels are indented just to easily visually group some related
+        # options together
+        labels = [
             "Layer",
             # This is hidden since it's usually not filtered to
             # "PseudoRootSpec",
             "PrimSpec",
             "    reference",
             "    payload",
-            "    variantSetName",
+            "    relocates",
             "AttributeSpec",
             "RelationshipSpec",
             "VariantSetSpec",
+            "    VariantSpec",
+            "    variantSetName",
+            "    variantSelections",
+        ]
+        tooltips = {
+            "Layer": "A single <b>Layer</b> in the stage.",
+            "PrimSpec": "A <b>Prim</b> description",
+            "AttributeSpec": "A property that holds typed data.",
+            "reference": "Represents a reference.",
+            "payload": (
+                "Represents a payload.<br>"
+                "Payloads are similar to prim references with the major "
+                "difference that payloads are explicitly loaded by the user."
+            ),
+            "RelationshipSpec": (
+                "A property that contains a reference to "
+                "one or more prim specs."
+            ),
+            "VariantSetSpec": "A variant set.",
+            "VariantSpec": "A single variant opinion for a variant set.",
+            "variantSetName": "Defines available variant set name on a prim.",
+            "variantSelections": (
+                "Defines the selected variant for a variant set."
+            )
+        }
 
-            # TODO: Still to be implemented in the StageSdfModel
-            # "variantSelections",
-            # "variantSets",
-            # "relocates"
-        ])
+        for label in labels:
+            type_name = label.lstrip(" ")
+            item = QtWidgets.QListWidgetItem(label, self)
+
+            # Set color
+            item.setData(QtCore.Qt.ForegroundRole,
+                         StageSdfModel.Colors.get(type_name))
+
+            tooltip = tooltips.get(type_name)
+            if tooltip:
+                item.setData(QtCore.Qt.ToolTipRole, tooltip)
+
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
 
 

--- a/usd_qtpy/prim_spec_editor.py
+++ b/usd_qtpy/prim_spec_editor.py
@@ -305,7 +305,10 @@ class StageSdfModel(TreeModel):
 
         if role == QtCore.Qt.ToolTipRole:
             item = index.data(TreeModel.ItemRole)
-            return item.get("path")
+            path = item.get("path")
+            if path and isinstance(path, Sdf.Path):
+                path = path.pathString
+            return path
 
         return super(StageSdfModel, self).data(index, role)
 

--- a/usd_qtpy/prim_spec_editor.py
+++ b/usd_qtpy/prim_spec_editor.py
@@ -276,7 +276,7 @@ class StageSdfModel(TreeModel):
 
         return super(StageSdfModel, self).flags(index)
 
-    def setData(self, index, value, role):
+    def setData(self, index, value, role) -> bool:
 
         if index.column() == 1:  # specifier
             item = index.internalPointer()
@@ -287,6 +287,9 @@ class StageSdfModel(TreeModel):
                 }
                 value = lookup[value]
                 spec.specifier = value
+                return True
+
+        return super(StageSdfModel, self).setData(index, value, role)
 
     def data(self, index, role):
 

--- a/usd_qtpy/prim_spec_editor.py
+++ b/usd_qtpy/prim_spec_editor.py
@@ -529,8 +529,9 @@ class SpecEditsWidget(QtWidgets.QWidget):
 
         with Sdf.ChangeBlock():
             for spec in specs:
-                log.debug(f"Removing spec: %s", spec.path)
-                remove_spec(spec)
+                if spec and not spec.expired:
+                    log.debug(f"Removing spec: %s", spec.path)
+                    remove_spec(spec)
             for deletable in deletables:
                 deletable.delete()
         return True

--- a/usd_qtpy/variants.py
+++ b/usd_qtpy/variants.py
@@ -243,6 +243,10 @@ class VariantSetWidget(QtWidgets.QWidget):
                 if index != -1:
                     del list_proxy[index]
 
+            # Remove variant selection opinion
+            if variant_set_name in prim_spec.variantSelections:
+                del prim_spec.variantSelections[variant_set_name]
+
         self.variant_set_deleted.emit()
 
     def on_add_variant(self):
@@ -286,6 +290,12 @@ class VariantSetWidget(QtWidgets.QWidget):
             variant_spec = variant_set_spec.variants.get(variant_name)
             if variant_spec:
                 variant_set_spec.RemoveVariant(variant_spec)
+
+            # Also remove the variant selection if it's set to the removed
+            # variant
+            selected = prim_spec.variantSelections.get(variant_set_name)
+            if variant_name == selected:
+                del prim_spec.variantSelections[variant_set_name]
 
     def on_set_edit_target(self, variant_name, state):
         """Callback when a variant is set to be the edit target"""

--- a/usd_qtpy/variants.py
+++ b/usd_qtpy/variants.py
@@ -18,7 +18,7 @@ def is_direct_variant_edit_target(
     """Return whether edit target targets the variant set's variant.
 
     It does not care on which layer it is targeting and whether the prim
-    even or its variant sets even exist on that layer.
+    or its variant sets even exist on that layer.
 
     This would return true for edit targets that were made directly on the
     layer, using e.g.:

--- a/usd_qtpy/variants.py
+++ b/usd_qtpy/variants.py
@@ -1,4 +1,13 @@
+import logging
+from functools import partial
+
 from qtpy import QtWidgets, QtCore
+from pxr import Usd, Tf
+
+from .lib.usd import LIST_ATTRS
+from .resources import get_icon
+
+log = logging.getLogger(__name__)
 
 
 class CreateVariantSetDialog(QtWidgets.QDialog):
@@ -34,3 +43,299 @@ class CreateVariantSetDialog(QtWidgets.QDialog):
             name = prompt.name.text()
             if name:
                 return name
+
+
+class Separator(QtWidgets.QFrame):
+    def __init__(self, thickness=2, parent=None):
+        super(Separator, self).__init__(parent=parent)
+        self.setFrameShape(QtWidgets.QFrame.HLine)
+        self.setFrameShadow(QtWidgets.QFrame.Sunken)
+        self.setLineWidth(thickness)
+        self.setFixedHeight(thickness)
+        self.setSizePolicy(QtWidgets.QSizePolicy.Minimum,
+                           QtWidgets.QSizePolicy.Expanding)
+        self.setStyleSheet("background-color: #21252B;")
+
+
+class VariantSetWidget(QtWidgets.QWidget):
+    """Widget for a single variant set"""
+
+    variant_set_deleted = QtCore.Signal()
+
+    def __init__(self, variant_set, parent=None):
+        super(VariantSetWidget, self).__init__(parent=parent)
+
+        self._listeners = []
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 13, 0, 0)
+
+        self._variant_set = variant_set
+        variant_set_name = variant_set.GetName()
+
+        layout.addWidget(Separator(thickness=1))
+        header_layout = QtWidgets.QHBoxLayout()
+        header_layout.setContentsMargins(0, 0, 0, 0)
+        label = QtWidgets.QLabel(f"<h3>{variant_set_name}</h3>")
+        label.setAlignment(QtCore.Qt.AlignCenter)
+        delete_button = QtWidgets.QPushButton(get_icon("x"), "")
+        delete_button.setFixedWidth(20)
+        delete_button.clicked.connect(self.on_delete_variant_set)
+        header_layout.addWidget(label)
+        header_layout.addWidget(delete_button)
+        layout.addLayout(header_layout)
+        layout.addWidget(Separator(thickness=1))
+
+        group = QtWidgets.QGroupBox()
+        grid_layout = QtWidgets.QGridLayout(group)
+        # indent to variant set header
+        grid_layout.setContentsMargins(0, 0, 0, 0)
+        grid_layout.setRowStretch(0, 1)
+        layout.addWidget(group)
+
+        add_icon = get_icon("plus")
+        add_button = QtWidgets.QPushButton(add_icon, "Add variant")
+        add_button.setToolTip(f"Add variant for {variant_set_name}")
+        add_button.setFocusPolicy(QtCore.Qt.StrongFocus)
+        add_button.clicked.connect(self.on_add_variant)
+        layout.addWidget(add_button)
+        layout.addStretch()
+
+        self.grid_layout = grid_layout
+        self.add_button = add_button
+
+    def refresh(self):
+        # Clear all widgets in the grid layout
+        def clear(layout: QtWidgets.QGridLayout):
+            """Clear a QGridLayout
+
+            This does not consider items spanning more than one row.
+            """
+            for index in reversed(range(layout.count())):
+                layout_item = layout.takeAt(index)
+                widget = layout_item.widget()
+                if widget:
+                    widget.deleteLater()
+            layout.invalidate()
+
+        clear(self.grid_layout)
+
+        for variant_name in self._variant_set.GetVariantNames():
+            self._add_variant(variant_name)
+
+    def on_notice(self, notice, sender):
+        self.refresh()
+
+    def showEvent(self, event):
+        # Refresh once, then register listeners to stay sync
+        self.refresh()
+        stage = self._variant_set.GetPrim().GetStage()
+        self._listeners.append(Tf.Notice.Register(
+            Usd.Notice.StageEditTargetChanged,
+            self.on_notice,
+            stage
+        ))
+        self._listeners.append(Tf.Notice.Register(
+            Usd.Notice.ObjectsChanged,
+            self.on_notice,
+            stage
+        ))
+
+    def hideEvent(self, event):
+        for listener in self._listeners:
+            listener.Revoke()
+        self._listeners.clear()
+
+    def _add_variant(self, variant_name):
+        grid_layout = self.grid_layout
+        row = grid_layout.rowCount()
+
+        select_button = QtWidgets.QRadioButton(variant_name)
+        is_selected = self._variant_set.GetVariantSelection() == variant_name
+        select_button.setChecked(is_selected)
+        select_button.toggled.connect(partial(self.on_select_variant,
+                                              variant_name))
+
+        set_edit_target_button = QtWidgets.QPushButton(get_icon("edit-2"), "")
+        set_edit_target_button.setFixedWidth(20)
+        set_edit_target_button.setCheckable(True)
+        set_edit_target_button.toggled.connect(partial(self.on_set_edit_target,
+                                               variant_name))
+        delete_button = QtWidgets.QPushButton(get_icon("x"), "")
+        delete_button.setFixedWidth(20)
+        delete_button.clicked.connect(partial(self.on_delete_variant,
+                                              variant_name, row))
+
+        grid_layout.addWidget(select_button, row, 0)
+        grid_layout.addWidget(set_edit_target_button, row, 1)
+        grid_layout.addWidget(delete_button, row, 2)
+
+    def on_delete_variant_set(self):
+        # Remove specs across all layers regarding this variant set
+        # Question: Does this include specs by referenced/payloads as well.
+        #   If so I presume we don't want to include those?
+        prim: Usd.Prim = self._variant_set.GetPrim()
+        variant_set_name = self._variant_set.GetName()
+        for prim_spec in prim.GetPrimStack():
+            if prim_spec.expired:
+                continue
+
+            if variant_set_name in prim_spec.variantSets:
+                del prim_spec.variantSets[variant_set_name]
+
+            for key in LIST_ATTRS:
+                list_proxy = getattr(prim_spec.variantSetNameList, key)
+                index = list_proxy.index(variant_set_name)
+                if index != -1:
+                    del list_proxy[index]
+
+        self.variant_set_deleted.emit()
+
+    def on_add_variant(self):
+        name, ok = QtWidgets.QInputDialog.getText(
+            self,
+            "Create Variant",
+            "Variant Name:"
+        )
+        if ok and name and not self._variant_set.HasAuthoredVariant(name):
+            # Create the variant
+            self._variant_set.AddVariant(name)
+
+    def on_delete_variant(self, variant_name, row):
+        """Callback when a variant is clicked to be deleted"""
+
+        def remove_row(layout: QtWidgets.QGridLayout, remove_row):
+            """Remove row in QGridLayout
+
+            This does not consider items spanning more than one row.
+            """
+            for index in reversed(range(layout.count())):
+                row, column, row_span, column_span = layout.getItemPosition(
+                    index
+                )
+                if row == remove_row:
+                    layout_item = layout.takeAt(index)
+                    widget = layout_item.widget()
+                    if widget:
+                        widget.deleteLater()
+
+        # Remove specs across all layers regarding this variant set
+        # Question: Does this include specs by referenced/payloads as well.
+        #   If so I presume we don't want to include those?
+        prim: Usd.Prim = self._variant_set.GetPrim()
+        variant_set_name = self._variant_set.GetName()
+        for prim_spec in prim.GetPrimStack():
+            variant_set_spec = prim_spec.variantSets.get(variant_set_name)
+            if not variant_set_spec:
+                continue
+
+            variant_spec = variant_set_spec.variants.get(variant_name)
+            if variant_spec:
+                variant_set_spec.RemoveVariant(variant_spec)
+
+    def on_set_edit_target(self, variant_name, state):
+        """Callback when a variant is set to be the edit target"""
+
+        stage = self._variant_set.GetPrim().GetStage()
+        if state:
+            if self._variant_set.GetVariantSelection() != variant_name:
+                self._variant_set.SetVariantSelection(variant_name)
+
+            # For now don't allow authoring variants in variants in variants
+            # because it's complex to define how that edit context should
+            # be visualized
+            # TODO: Support editing in nested variant edit contexts
+            layer = stage.GetEditTarget().GetLayer()
+            edit_target = self._variant_set.GetVariantEditTarget(layer)
+            stage.SetEditTarget(edit_target)
+        else:
+            # Target the parent layer for current edit target
+            current_edit_target = stage.GetEditTarget()
+            layer = current_edit_target.GetLayer()
+            edit_target = stage.GetEditTargetForLocalLayer(layer)
+            stage.SetEditTarget(edit_target)
+
+    def on_select_variant(self, variant_name, state):
+        if not state:
+            return
+
+        if self._variant_set.GetVariantSelection() != variant_name:
+            self._variant_set.SetVariantSelection(variant_name)
+
+
+class VariantSetsWidget(QtWidgets.QDialog):
+    """Manage the variant sets and variants for a Usd.Prim"""
+    def __init__(self, prim, parent=None):
+        super(VariantSetsWidget, self).__init__(parent=parent)
+
+        title = "Variant Sets"
+        if prim and prim.IsValid():
+            title = f"{title}: {prim.GetPath().pathString}"
+        self.setWindowTitle(title)
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        add_icon = get_icon("plus")
+        add_button = QtWidgets.QPushButton(add_icon, "Add variant set")
+        add_button.setToolTip("Add variant set")
+        add_button.clicked.connect(self.on_add_variant_set)
+        layout.addWidget(add_button)
+
+        variant_sets_layout = QtWidgets.QVBoxLayout()
+        variant_sets_layout.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(variant_sets_layout)
+
+        layout.addStretch()
+
+        self.prim = prim
+        self.variant_sets_layout = variant_sets_layout
+
+        self.refresh()
+
+    def refresh(self):
+
+        def clear(layout):
+            for i in reversed(range(layout.count())):
+                layout_item = layout.takeAt(i)
+                widget = layout_item.widget()
+                if widget:
+                    widget.deleteLater()
+            layout.invalidate()
+
+        clear(self.variant_sets_layout)
+
+        # Store items and widgets for the references
+        prim = self.prim
+
+        # TODO: It is possible to have an authored variant selection
+        #  without the variant set being authored in the current stage.
+        #  For those cases we might want to expose being able to set e.g.
+        #  a custom variant selection and display those that do not have
+        #  an existing variant or even variant set on the composed stage.
+        #  E.g. see: Usd.VariantSets.GetAllVariantSelections
+
+        variant_sets = prim.GetVariantSets()
+        for variant_set_name in variant_sets.GetNames():
+            # Add a variant set widget with its variants
+            variant_set = variant_sets.GetVariantSet(variant_set_name)
+            variant_set_widget = VariantSetWidget(variant_set=variant_set,
+                                                  parent=self)
+            variant_set_widget.variant_set_deleted.connect(self.refresh)
+            self.variant_sets_layout.addWidget(variant_set_widget)
+
+    def on_add_variant_set(self):
+        log.debug("Add variant set")
+        prim = self.prim
+        assert prim.IsValid()
+        name, ok = QtWidgets.QInputDialog.getText(
+            self,
+            "Create Variant Set",
+            "Variant Set Name:"
+        )
+        if ok and name:
+            # Create the variant set, even allowing to create it
+            # without populating a variant name. If it already exists
+            # this does nothing.
+            prim.GetVariantSets().AddVariantSet(name)
+
+        self.refresh()

--- a/usd_qtpy/viewer.py
+++ b/usd_qtpy/viewer.py
@@ -6,6 +6,7 @@ from qtpy import QtWidgets, QtCore, QtGui
 from pxr import Usd, UsdGeom, Tf
 from pxr.Usdviewq.stageView import StageView
 from pxr.Usdviewq import common
+from pxr.UsdAppUtils.complexityArgs import RefinementComplexities
 
 try:
     # Use C++ implementation of USD View
@@ -309,6 +310,19 @@ class Widget(QtWidgets.QWidget):
             shading_menu.addAction(action)
             group.addAction(action)
         group.triggered.connect(set_rendermode)
+
+        # Complexity
+        complexity_menu = menu.addMenu("Complexity")
+        current_complexity_name = self.model.viewSettings.complexity.name
+        for complexity in RefinementComplexities.ordered():
+            action = complexity_menu.addAction(complexity.name)
+            action.setCheckable(True)
+            action.setChecked(complexity.name == current_complexity_name)
+            def set_complexity(complexity):
+                self.model.viewSettings.complexity = complexity
+
+            action.triggered.connect(partial(set_complexity, complexity))
+
         # TODO: Set view settings
 
         purpose_menu = menu.addMenu("Display Purpose")


### PR DESCRIPTION
### Feature

- Adds basic support for Variant Set managements on a prim.
- You can now add/remove variant sets on a prim, add add/remove variants.
- You can also set the edit target to a variant

This PR also fixes some minor issues with the Prim Spec Editor:
- You can now remove `VariantSpec`
- It will now not error when you've selected a hierarchy of prim specs and remove them (this was only if debug log messages were handled)

### Screenshots

![variant_sets_editor](https://github.com/BigRoy/usd-qtpy/assets/2439881/82e835f9-1af0-4a02-ba2d-1dcff6f5d538)
