### PR TITLE
Enhancement: Add shortcuts to duplicate, rename, delete or group selected prims in prim hierarchy

### DIFF
--- a/usd_qtpy/prim_hierarchy.py
+++ b/usd_qtpy/prim_hierarchy.py
@@ -3,7 +3,14 @@ from functools import partial
 from qtpy import QtWidgets, QtCore
 from pxr import Sdf
 
-from .lib.usd import get_prim_types_by_group
+from .lib.usd import (
+    get_prim_types_by_group,
+    parent_prims,
+    remove_spec,
+    unique_name,
+)
+from .lib.usd_merge_spec import copy_spec_merge
+from .lib.qt import iter_model_rows
 from .prim_delegate import DrawRectsDelegate
 from .prim_hierarchy_model import HierarchyModel
 from .references import ReferenceListWidget
@@ -42,13 +49,8 @@ class View(QtWidgets.QTreeView):
             type_name = action.text()
 
             # Ensure unique name
-            base_path = parent_path.AppendChild(type_name)
-            prim_path = base_path
-            i = 1
-            while stage.GetPrimAtPath(prim_path):
-                prim_path = Sdf.Path(f"{base_path.pathString}{i}")
-                i += 1
-
+            prim_path = parent_path.AppendChild(type_name)
+            prim_path = unique_name(stage, prim_path)
             if type_name == "Def":
                 # Typeless
                 type_name = ""
@@ -57,7 +59,8 @@ class View(QtWidgets.QTreeView):
             # TODO: Remove signaling once model listens to changes
             current_rows = model.rowCount(index)
             model.beginInsertRows(index, current_rows, current_rows+1)
-            stage.DefinePrim(prim_path, type_name)
+            new_prim = stage.DefinePrim(prim_path, type_name)
+            self.select_paths([new_prim.GetPath()])
             model.endInsertRows()
 
         # Create Prims
@@ -164,6 +167,178 @@ class View(QtWidgets.QTreeView):
         elif text == "VAR":
             raise NotImplementedError("To be implemented")
 
+    def select_paths(self, paths: list[Sdf.Path]):
+        """Select prims in the hierarchy view that match the Sdf.Path
+
+        If an empty path list is provided or none matching paths are found
+        the selection is just cleared.
+
+        Arguments:
+            paths (list[Sdf.Path]): The paths to select.
+
+        """
+
+        model: HierarchyModel = self.model()
+        assert isinstance(model, HierarchyModel)
+        selection = QtCore.QItemSelection()
+
+        if not paths:
+            self.selectionModel().clear()
+            return
+
+        search = set(paths)
+        path_to_index = {}
+        for index in iter_model_rows(model, column=0):
+            # We iterate the model using its regular methods so we support both
+            # the model directly but also a proxy model. Also, this forces it
+            # to fetch the data if the model is lazy.
+            # TODO: This can be optimized by pruning the traversal if we
+            #   the current prim path is not a parent of the path we search for
+            if not search:
+                # Found all
+                break
+
+            prim = index.data(HierarchyModel.PrimRole)
+            if not prim:
+                continue
+
+            path = prim.GetPath()
+            path_to_index[path] = index
+            search.discard(path)
+
+        for path in paths:
+            index = path_to_index.get(path)
+            if not index:
+                # Path not found
+                continue
+
+            selection.select(index, index)
+
+        selection_model = self.selectionModel()
+        selection_model.select(selection,
+                               QtCore.QItemSelectionModel.ClearAndSelect |
+                               QtCore.QItemSelectionModel.Rows)
+
+    def keyPressEvent(self, event):
+        modifiers = event.modifiers()
+        ctrl_pressed = QtCore.Qt.ControlModifier & modifiers
+
+        # Group selected with Ctrl + G
+        if (
+            ctrl_pressed
+            and event.key() == QtCore.Qt.Key_G
+            and not event.isAutoRepeat()
+        ):
+            self._group_selected()
+            event.accept()
+            return
+
+        # Delete selected with delete key
+        if (
+            event.key() == QtCore.Qt.Key_Delete
+            and not event.isAutoRepeat()
+        ):
+            self._delete_selected()
+            event.accept()
+            return
+
+        # Duplicate selected with Ctrl + D
+        if (
+            ctrl_pressed
+            and event.key() == QtCore.Qt.Key_D
+            and not event.isAutoRepeat()
+        ):
+            self._duplicate_selected()
+            event.accept()
+            return
+
+        # Enter rename mode on current index when enter is pressed
+        if (
+            self.state() != QtWidgets.QAbstractItemView.EditingState
+            and event.key() in [QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter]
+        ):
+            self.edit(self.currentIndex())
+            event.accept()
+            return
+
+        return super(View, self).keyPressEvent(event)
+
+    def _group_selected(self):
+        """Group selected prims under a new Xform"""
+        selected = self.selectionModel().selectedIndexes()
+        prims = [index.data(HierarchyModel.PrimRole) for index in selected]
+
+        # Exclude root prims
+        prims = [prim for prim in prims if not prim.IsPseudoRoot()]
+        if not prims:
+            return
+
+        stage = prims[0].GetStage()
+        parent_path = prims[0].GetPath().GetParentPath()
+
+        group_path = parent_path.AppendChild("group")
+        group_path = unique_name(stage, group_path)
+
+        # Define a group
+        group = stage.DefinePrim(group_path, "Xform")
+
+        # Now we want to move all selected prims into this
+        parent_prims(prims, group.GetPath())
+
+        # If the original group was renamed but there's now no conflict
+        # anymore, e.g. we grouped `group` itself from the parent path
+        # then now we can safely rename it to `group` without conflicts
+        # TODO: Ensure grouping `group` doesn't make a `group1`
+        self.select_paths([group_path])
+
+    def _delete_selected(self):
+        """Delete prims across all layers in the layer stack"""
+        selected = self.selectionModel().selectedIndexes()
+        prims = [index.data(HierarchyModel.PrimRole) for index in selected]
+
+        # Exclude root prims
+        prims = [prim for prim in prims if not prim.IsPseudoRoot()]
+        if not prims:
+            return
+
+        # We first collect the prim specs before removing because the Usd.Prim
+        # will become invalid as we start removing specs
+        specs = []
+        for prim in prims:
+            specs.extend(prim.GetPrimStack())
+
+        with Sdf.ChangeBlock():
+            for spec in specs:
+                if spec.expired:
+                    continue
+
+                # Warning: This would also remove it from layers from
+                #   references/payloads!
+                # TODO: Filter specs for which their `.getLayer()` is a layer
+                #   from the Stage's layer stack?
+                remove_spec(spec)
+
+    def _duplicate_selected(self):
+        """Duplicate prim specs across all layers in the layer stack"""
+        selected = self.selectionModel().selectedIndexes()
+        prims = [index.data(HierarchyModel.PrimRole) for index in selected]
+
+        # Exclude root prims
+        prims = [prim for prim in prims if not prim.IsPseudoRoot()]
+        if not prims:
+            return []
+
+        new_paths = []
+        for prim in prims:
+            path = prim.GetPath()
+            stage = prim.GetStage()
+            new_path = unique_name(stage, path)
+            for spec in prim.GetPrimStack():
+                layer = spec.layer
+                copy_spec_merge(layer, path, layer, new_path)
+            new_paths.append(new_path)
+        self.select_paths(new_paths)
+
 
 class HierarchyWidget(QtWidgets.QDialog):
     def __init__(self, stage, parent=None):
@@ -175,6 +350,7 @@ class HierarchyWidget(QtWidgets.QDialog):
 
         model = HierarchyModel(stage=stage)
         view = View()
+        view.setSelectionMode(QtWidgets.QTreeView.ExtendedSelection)
         view.setModel(model)
 
         self.model = model


### PR DESCRIPTION
### Enhancement

Add shortcuts to duplicate, rename, delete or group selected prims in prim hierarchy
Also enables multiselection in the prim hierarchy.

Implements #23 

### Shortcuts

- [x] **CTRL+G**: group selected nodes into an Xform named `group`
- [x] **CTRL+D** duplicate selected nodes
- [x] **Delete**: delete selected nodes
- [x] **Enter**: edit name in view on current index (like F2 shortcut)

Skipped the following - those are better left for individual PRs:
- [ ] **Tab**: create nodes quickly from a type search popup menu (like e.g. creating nodes in Houdini, Nuke or Fusion)
    - This feature is sligthtly more involved because it needs its own "quick search" widget so might be best left for another PR.
- [ ] **Shift+click expand/collapse**: Expand or collapse all for the selected expand/collapse action (like maya)
- [ ] **F**: frame the current selected node? Or do we like the default tree view behavior where typing brings you to the closest name.