### PR TITLE
Enhancement: Create and manage anonymous layers

### DIFF
--- a/usd_qtpy/prim_spec_editor.py
+++ b/usd_qtpy/prim_spec_editor.py
@@ -117,7 +117,7 @@ class StageSdfModel(TreeModel):
         for layer in stage.GetLayerStack():
 
             layer_item = Item({
-                "name": layer.GetDisplayName(),
+                "name": layer.GetDisplayName() or layer.identifier,
                 "identifier": layer.identifier,
                 "specifier": None,
                 "type": layer.__class__.__name__
@@ -484,7 +484,8 @@ class SpecEditsWidget(QtWidgets.QWidget):
 
         stage = self.model._stage
         for layer in stage.GetLayerStack():
-            action = move_menu.addAction(layer.GetDisplayName())
+            label = layer.GetDisplayName() or layer.identifier
+            action = move_menu.addAction(label)
             action.setData(layer)
 
         def move_to(action):


### PR DESCRIPTION
### Feature

You can now create and save anonymous layers from the layer editor.

- Allow adding + saving anonymous layers
- Show save icon on anonymous layers
- Show label "anonymousLayer" for anonymous layer without a tag

Other fixes:

- fix drag/drop on self breaking layers in layer editor,
- fix drag not working on italic text of anonymous layers
- fix showing empty labels for anonymous layers without tags in Prim Spec editor 
- add multiselection in the layer editor
- make remove layer and reload layer work on the multiselection