### PR TITLE
Bump version to 0.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 description = "Python Qt components for building custom USD tools."
 readme = "README.md"
-requires-python = ">=3.4"
+requires-python = ">=3.8"
 keywords = ["usd", "qt"]
 license = { file = "LICENSE" }
 classifiers = [
@@ -23,9 +23,9 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    'importlib-metadata; python_version<"3.7"', "qtpy"
+    "qtpy"
 ]
-version = "0.0.2"
+version = "0.0.3"
 
 [project.optional-dependencies]
 usd = ["usd-core"]

--- a/usd_qtpy/version.py
+++ b/usd_qtpy/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring usd_qtpy version."""
-__version__ = "0.0.2"
+__version__ = "0.0.3"


### PR DESCRIPTION
Also bump minimal python version to 3.8 since we use f-string formatting (Py3.6+) and walrus operator (Py3.8+) in `pyproject.toml`

Bump version for next release